### PR TITLE
Build Docker image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,49 @@
+on: push
+
+name: Docker image
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.4
+        extensions: dom, zip
+        coverage: none
+        tools: composer:v2
+    - name: Install PHP dependencies
+      run: |
+        composer install --no-interaction --no-progress
+    - name: Build theme
+      working-directory: web/profiles/custom/os2loop/themes/os2loop_theme
+      run: |
+        yarn install
+        yarn build
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      # We only push from the default branch, so no need to login from elsewhere.
+      if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        # Only push the image if this is a push to the default branch.
+        push: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        context: .
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.version=${{ github.sha }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        tags: |
+          ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# There is no tagged version of tianon/true.
+# hadolint ignore=DL3007
+FROM tianon/true:latest
+
+COPY . /var/www


### PR DESCRIPTION
On pushes to the main branch we build a Docker image containing the code, PHP dependencies installed (`composer install`), theme dependencies installed (`yarn install`), and the theme build (`yarn
build`).

The Docker image _only_ contains files and no PHP, FPM, ...
